### PR TITLE
aws-actions/setup-sam を github actions workflow から削除

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: aws-actions/setup-sam@v2
     - run: npm ci
     - uses: aws-actions/configure-aws-credentials@v4
       with:


### PR DESCRIPTION
現在の ubuntu-latest では AWS SAM CLI がデフォルトでインストールされているため、追加でインストールするアクションは不要。
https://github.com/actions/runner-images/blob/ubuntu22/20240922.1/images/ubuntu/Ubuntu2404-Readme.md