### PR TITLE
Feature/packaging deps

### DIFF
--- a/packages/api/build.mjs
+++ b/packages/api/build.mjs
@@ -1,0 +1,10 @@
+import * as esbuild from 'esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/standalone.ts'],
+  bundle: true,
+  outfile: 'dist/index.js',
+  target: 'es2020',
+  platform: 'node',
+  external: ['@aws-sdk', '@fastify/swagger', '@fastify/swagger-ui'],
+});

--- a/packages/api/build.sh
+++ b/packages/api/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# デプロイパッケージ用のディレクトリを作成
+mkdir -p .aws-sam/build/MyFunction
+
+# 外部ライブラリをインストール
+npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @fastify/swagger@9 @fastify/swagger-ui@5 --prefix .aws-sam/build/MyFunction
+
+# # ソースコードをビルド ... は sam build に任せる
+# esbuild src/index.ts \
+#   --bundle \
+#   --minify \
+#   --sourcemap \
+#   --platform=node \
+#   --target=es2020 \
+#   '--external:@aws-sdk' \
+#   '--external:@fastify/swagger' \
+#   '--external:@fastify/swagger-ui' \
+#   --outfile=.aws-sam/build/MyFunction/index.js

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,7 +8,10 @@
     "sam": "sam",
     "sam:build": "sam build",
     "sam:deploy": "sam deploy --no-confirm-changeset --no-fail-on-empty-changeset",
-    "builddeploy": "run-s sam:build sam:deploy"
+    "builddeploy": "run-s sam:build custombuild sam:deploy",
+    "buildlocal": "node build.mjs",
+    "startlocal": "node dist/index.js",
+    "custombuild": "./build.sh"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.758.0",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -26,32 +26,31 @@ export const createApp = async () => {
   });
   await fastify.register(fastifySwaggerUi, {
     routePrefix: '/api/docs',
+    logo: { type: '', content: '' },
   });
 
-  fastify.after(() => {
-    fastify.get(
-      '/',
-      {
-        schema: {
-          summary: 'Hello world',
-          tags: ['general'],
-          response: {
-            '200': {
-              type: 'object',
-              properties: {
-                message: { type: 'string' },
-              },
+  fastify.get(
+    '/',
+    {
+      schema: {
+        summary: 'Hello world',
+        tags: ['general'],
+        response: {
+          '200': {
+            type: 'object',
+            properties: {
+              message: { type: 'string' },
             },
           },
         },
       },
-      async (_req, _reply) => {
-        return { message: 'Hello world' };
-      },
-    );
+    },
+    async (_req, _reply) => {
+      return { message: 'Hello world' };
+    },
+  );
 
-    fastify.register(apiRouter, { prefix: '/api' });
-  });
+  fastify.register(apiRouter, { prefix: '/api' });
 
   return fastify;
 };

--- a/packages/api/template.yaml
+++ b/packages/api/template.yaml
@@ -42,6 +42,8 @@ Resources:
           - index.ts
         External:
           - '@aws-sdk'
+          - '@fastify/swagger'
+          - '@fastify/swagger-ui'
 
   # AWS::Serverless::Function の FunctionUrlConfig ではエイリアス (Qualifier) 込みの Function URL を定義できないため
   # 明示的に AWS::Lambda::Url リソースとして宣言する


### PR DESCRIPTION
- swagger-ui で logo を指定しないと esbuild でビルド時にロゴファイルがパッケージからこぼれて実行時に「ファイルが見つからない」エラーになるため、意図的に枠をつぶしておく
- `@fastify/swagger-ui` を esbuild でビルド対象にすると、logo 以外にも css ファイルなどがパッケージに含まれず実行時エラーが多発するため、external 指定する
  - そのままではパッケージに含まれなくなるため、カスタムスクリプトを用意して `sam build` と `sam deploy` の間で `npm install` して明示的にパッケージに含めるようにする