### PR TITLE
sam deploy 時の parameter-overrides の指定方法を変える

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -38,7 +38,10 @@ jobs:
         role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
         aws-region: ap-northeast-1
     - run: npm run build:api
-    - run: npm run deploy:api -- --parameter-overrides MyDistributionId=${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} BucketBackend=${{ secrets.BUCKET_BACKEND }}
+    - run: npm run deploy:api
+      env:
+        CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        BUCKET_BACKEND: ${{ secrets.BUCKET_BACKEND }}
     - run: npm run prune -w @avshare3/api
       env:
         FUNCTION_NAME: ${{ secrets.FUNCTION_NAME }}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
     "lint": "npx eslint .",
     "sam": "sam",
     "sam:build": "sam build",
-    "sam:deploy": "sam deploy --no-confirm-changeset --no-fail-on-empty-changeset",
+    "sam:deploy": "sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides MyDistributionId=${CLOUDFRONT_DISTRIBUTION_ID} BucketBackend=${BUCKET_BACKEND}",
     "build": "npm run sam:build",
     "postbuild": "./build.sh",
     "deploy": "npm run sam:deploy",


### PR DESCRIPTION
npm run script の後に -- でつなげる方法だと npm run を何段も重ねたときに --parameter-overrides が消失してエラーになるため