### PR TITLE
TypeBox を使ってバリデーションロジックをリファクタリング

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1589,18 +1589,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/standalone": {
       "version": "7.26.7",
       "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.26.7.tgz",
@@ -2802,15 +2790,6 @@
         "openapi-types": "^12.1.3",
         "rfdc": "^1.3.1",
         "yaml": "^2.4.1"
-      }
-    },
-    "node_modules/@fastify/type-provider-json-schema-to-ts": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/type-provider-json-schema-to-ts/-/type-provider-json-schema-to-ts-5.0.0.tgz",
-      "integrity": "sha512-erEJvxucxc09XLdHygdQua4QFyxBp+QParhXl3hrB6UvE2R6ZB9KG6TznUTz6I5HK7t5xm/vn4DG7EIOAPOO4w==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.0"
       }
     },
     "node_modules/@h4ad/serverless-adapter": {
@@ -13285,19 +13264,6 @@
         "url": "https://github.com/Eomm/json-schema-resolver?sponsor=1"
       }
     },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/json-schema-to-typescript-lite": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/json-schema-to-typescript-lite/-/json-schema-to-typescript-lite-14.1.0.tgz",
@@ -16599,12 +16565,6 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
-    },
     "node_modules/regexp-ast-analysis": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
@@ -18240,12 +18200,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -20004,7 +19958,6 @@
         "@fastify/helmet": "^12.0.1",
         "@fastify/swagger": "^9.4.2",
         "@fastify/swagger-ui": "^5.2.2",
-        "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
         "@h4ad/serverless-adapter": "^4.4.0",
         "fastify": "^5.2.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19959,8 +19959,15 @@
         "@fastify/swagger": "^9.4.2",
         "@fastify/swagger-ui": "^5.2.2",
         "@h4ad/serverless-adapter": "^4.4.0",
+        "@sinclair/typebox": "^0.34.28",
         "fastify": "^5.2.1"
       }
+    },
+    "packages/api/node_modules/@sinclair/typebox": {
+      "version": "0.34.28",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.28.tgz",
+      "integrity": "sha512-e2B9vmvaa5ym5hWgCHw5CstP54au6AOLXrhZErLsOyyRzuWJtXl/8TszKtc5x8rw/b+oY7HKS9m9iRI53RK0WQ==",
+      "license": "MIT"
     },
     "packages/gui": {
       "name": "@avshare3/gui",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,6 +23,7 @@
     "@fastify/swagger": "^9.4.2",
     "@fastify/swagger-ui": "^5.2.2",
     "@h4ad/serverless-adapter": "^4.4.0",
+    "@sinclair/typebox": "^0.34.28",
     "fastify": "^5.2.1"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,6 @@
     "@fastify/helmet": "^12.0.1",
     "@fastify/swagger": "^9.4.2",
     "@fastify/swagger-ui": "^5.2.2",
-    "@fastify/type-provider-json-schema-to-ts": "^5.0.0",
     "@h4ad/serverless-adapter": "^4.4.0",
     "fastify": "^5.2.1"
   }

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -1,54 +1,15 @@
-import type { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import type { JSONSchema } from 'json-schema-to-ts/lib/types/definitions';
+import type { FastifyPluginAsync } from 'fastify';
 import { fetchContentsList } from '~/services/fetchContentsList';
+import {
+  ErrorInfo,
+  type ErrorInfoType,
+  QueryParam,
+  type QueryParamType,
+  UrlInfoList,
+  type UrlInfoListType,
+} from '~/types';
 
-const schemaQueryParam = {
-  $id: 'schema:QueryParam',
-  type: 'object',
-  properties: {
-    prefix: { type: 'string' },
-  },
-  additionalProperties: false,
-  required: ['prefix'],
-} as const satisfies JSONSchema;
-
-const schemaUrlInfoList = {
-  $id: 'schema:UrlInfoList',
-  description: 'Successful response',
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      url: { type: 'string' },
-      title: { type: 'string' },
-    },
-    additionalProperties: false,
-    required: ['url', 'title'],
-  },
-} as const satisfies JSONSchema;
-
-const schemaErrorInfo = {
-  $id: 'schema:ErrorInfo',
-  description: 'Error response',
-  type: 'object',
-  properties: {
-    statusCode: { type: 'number' },
-    error: { type: 'string' },
-    message: { type: 'string' },
-  },
-  additionalProperties: false,
-} as const satisfies JSONSchema;
-
-export const apiRouter: FastifyPluginAsyncJsonSchemaToTs<{
-  ValidatorSchemaOptions: {
-    references: [typeof schemaQueryParam];
-  };
-  SerializerSchemaOptions: {
-    references: [typeof schemaUrlInfoList, typeof schemaErrorInfo];
-  };
-}> = async (fastify, _opts) => {
-  fastify.addSchema(schemaQueryParam).addSchema(schemaUrlInfoList).addSchema(schemaErrorInfo);
-
+export const apiRouter: FastifyPluginAsync = async (fastify, _opts) => {
   fastify.get(
     '/',
     {
@@ -70,22 +31,19 @@ export const apiRouter: FastifyPluginAsyncJsonSchemaToTs<{
     },
   );
 
-  fastify.get(
+  fastify.get<{
+    Querystring: QueryParamType;
+    Reply: UrlInfoListType | ErrorInfoType;
+  }>(
     '/contentsList',
     {
       schema: {
         summary: 'Get contents list',
         tags: ['general'],
-        querystring: {
-          $ref: 'schema:QueryParam',
-        },
+        querystring: QueryParam,
         response: {
-          '200': {
-            $ref: 'schema:UrlInfoList',
-          },
-          default: {
-            $ref: 'schema:ErrorInfo',
-          },
+          '200': UrlInfoList,
+          default: ErrorInfo,
         },
       },
     },

--- a/packages/api/src/services/fetchContentsList.ts
+++ b/packages/api/src/services/fetchContentsList.ts
@@ -1,7 +1,7 @@
-import type { UrlInfo } from '~/types';
+import type { UrlInfoListType } from '~/types';
 import { listUrls } from './listUrls';
 
-export const fetchContentsList = async (prefix: string): Promise<UrlInfo[]> => {
+export const fetchContentsList = async (prefix: string): Promise<UrlInfoListType> => {
   const bucket = process.env.BUCKET_NAME!;
   const urls = await listUrls(bucket, prefix);
   return urls;

--- a/packages/api/src/services/listUrls.ts
+++ b/packages/api/src/services/listUrls.ts
@@ -1,5 +1,5 @@
 import { generateSignedUrl, getS3Object } from '~/repositories';
-import type { IndexSchema, UrlInfo } from '~/types';
+import type { IndexSchema, UrlInfoListType } from '~/types';
 
 export const listUrls = async (bucket: string, prefix: string) => {
   // S3からindex.jsonをダウンロード
@@ -7,7 +7,7 @@ export const listUrls = async (bucket: string, prefix: string) => {
   const index = JSON.parse(data) as IndexSchema;
 
   // index.jsonのfiles[].{file, title}を取得し、fileをsingedUrlに変換する
-  const urls: UrlInfo[] = [];
+  const urls: UrlInfoListType = [];
   for (let i = 0; i < index.files.length; i++) {
     const item = index.files[i];
     const url = await generateSignedUrl(bucket, `${prefix}/${item.file}`);

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Static, Type } from '@sinclair/typebox';
+import { type Static, Type } from '@sinclair/typebox';
 
 export interface IndexFileSchema {
   file: string;

--- a/packages/api/src/types/index.ts
+++ b/packages/api/src/types/index.ts
@@ -1,3 +1,5 @@
+import { Static, Type } from '@sinclair/typebox';
+
 export interface IndexFileSchema {
   file: string;
   title: string;
@@ -8,7 +10,22 @@ export interface IndexSchema {
   files: IndexFileSchema[];
 }
 
-export interface UrlInfo {
-  url: string;
-  title: string;
-}
+export const UrlInfo = Type.Object({
+  url: Type.String(),
+  title: Type.String(),
+});
+export const UrlInfoList = Type.Array(UrlInfo);
+export type UrlInfoType = Static<typeof UrlInfo>;
+export type UrlInfoListType = Static<typeof UrlInfoList>;
+
+export const QueryParam = Type.Object({
+  prefix: Type.String(),
+});
+export type QueryParamType = Static<typeof QueryParam>;
+
+export const ErrorInfo = Type.Object({
+  statusCode: Type.Number(),
+  error: Type.String(),
+  message: Type.String(),
+});
+export type ErrorInfoType = Static<typeof ErrorInfo>;

--- a/packages/gui/components/MainContent.vue
+++ b/packages/gui/components/MainContent.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import type { UrlInfo } from '@avshare3/api/src/types';
+import type { UrlInfoListType } from '@avshare3/api/src/types';
 
 // get config
 const config = useRuntimeConfig();
@@ -48,7 +48,7 @@ watchEffect(async () => {
 
   showLoading.value = true;
   try {
-    const { data: result } = await useFetch<UrlInfo[]>('/contentsList', {
+    const { data: result } = await useFetch<UrlInfoListType>('/contentsList', {
       baseURL: config.public.apiBase,
       query: {
         prefix: prefix.value,

--- a/packages/gui/composables/useUrls.ts
+++ b/packages/gui/composables/useUrls.ts
@@ -1,7 +1,7 @@
-import type { UrlInfo } from '@avshare3/api/src/types';
+import type { UrlInfoListType } from '@avshare3/api/src/types';
 
 /**
  * 状態 "urls" を参照する。初期値は空配列。
  * @returns state "urls"
  */
-export const useUrls = () => useState<UrlInfo[]>(() => []);
+export const useUrls = () => useState<UrlInfoListType>(() => []);


### PR DESCRIPTION
#65 の `@fastify/type-provider-json-schema-to-ts` を使った方法よりも TypeBox を使った方法のほうがシンプルかつ TypeScript との親和性が高いので、TypeBox を使ってリファクタリング。

cf) https://fastify.dev/docs/latest/Reference/TypeScript/#typebox