### PR TITLE
Pin vue, @vue/test-utils, @nuxt/test-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3231,9 +3231,9 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/test-utils": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@nuxt/test-utils/-/test-utils-4.0.3.tgz",
-      "integrity": "sha512-HwF3B+GIwzWeIioskhHIjq+TQttP7+g0GUO39hpivGWFZzYXD3lIspzfmliJkgwwA3m5Xl2Z8XXqX1zAolKX6w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/test-utils/-/test-utils-4.0.2.tgz",
+      "integrity": "sha512-bexdsG2HbkSiCNt+2qwHBtPd6zNUYoZ8Pa+70uTkeHuYzCC6GXWb+CyEiFqE0Pd+A/7nrBflebKW0sGWGCR/uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3242,7 +3242,7 @@
         "@nuxt/kit": "^3.21.2",
         "c12": "^3.3.4",
         "consola": "^3.4.2",
-        "defu": "^6.1.7",
+        "defu": "^6.1.4",
         "destr": "^2.0.5",
         "estree-walker": "^3.0.3",
         "exsolve": "^1.0.8",
@@ -3254,18 +3254,18 @@
         "magic-string": "^0.30.21",
         "node-fetch-native": "^1.6.7",
         "node-mock-http": "^1.0.4",
-        "nypm": "^0.6.6",
+        "nypm": "^0.6.5",
         "ofetch": "^1.5.1",
         "pathe": "^2.0.3",
         "perfect-debounce": "^2.1.0",
         "radix3": "^1.1.2",
         "scule": "^1.3.0",
-        "std-env": "^4.1.0",
+        "std-env": "^4.0.0",
         "tinyexec": "^1.1.1",
         "ufo": "^1.6.3",
         "unplugin": "^3.0.0",
         "vitest-environment-nuxt": "2.0.0",
-        "vue": "^3.5.33"
+        "vue": "^3.5.32"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -3361,129 +3361,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/compiler-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
-      "integrity": "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.33",
-        "entities": "^7.0.1",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/compiler-core/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/compiler-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.33.tgz",
-      "integrity": "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.33",
-        "@vue/shared": "3.5.33"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.33.tgz",
-      "integrity": "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.33",
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.21",
-        "postcss": "^8.5.10",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.33.tgz",
-      "integrity": "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/shared": "3.5.33"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/reactivity": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
-      "integrity": "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.33"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/runtime-core": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.33.tgz",
-      "integrity": "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/shared": "3.5.33"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/runtime-dom": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.33.tgz",
-      "integrity": "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "3.5.33",
-        "@vue/runtime-core": "3.5.33",
-        "@vue/shared": "3.5.33",
-        "csstype": "^3.2.3"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/server-renderer": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.33.tgz",
-      "integrity": "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.5.33",
-        "@vue/shared": "3.5.33"
-      },
-      "peerDependencies": {
-        "vue": "3.5.33"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/@vue/shared": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.33.tgz",
-      "integrity": "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@nuxt/test-utils/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3533,28 +3410,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@nuxt/test-utils/node_modules/vue": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.33.tgz",
-      "integrity": "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.33",
-        "@vue/compiler-sfc": "3.5.33",
-        "@vue/runtime-dom": "3.5.33",
-        "@vue/server-renderer": "3.5.33",
-        "@vue/shared": "3.5.33"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nuxt/vite-builder": {
@@ -7468,9 +7323,9 @@
       "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
-      "version": "2.4.9",
-      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.9.tgz",
-      "integrity": "sha512-YwgowiO1mPleZqpgAGfxvWu/A5A8nkLrbyH2SqiQRkyzCIaDzzo27/2uS/F1g7fRLvl8BUY0+Sr1eC+6+IHfrw==",
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.8.tgz",
+      "integrity": "sha512-cjAKFbSXFhtZ9Cj+ug60b21lW/BN737e+Syu2LPACIW6R0zVtj65Fnfe649KjfHor3Etx3ZavDFFBrZ+p21YNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9381,9 +9236,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12076,9 +11931,9 @@
       "license": "MIT"
     },
     "node_modules/js-beautify/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18600,12 +18455,12 @@
         "@pinia/nuxt": "^0.11.3",
         "nuxt": "^4.4.2",
         "pinia": "^3.0.4",
-        "vue": "^3.5.30"
+        "vue": "3.5.32"
       },
       "devDependencies": {
         "@avshare3/api": "*",
-        "@nuxt/test-utils": "^4.0.3",
-        "@vue/test-utils": "^2.4.9",
+        "@nuxt/test-utils": "4.0.2",
+        "@vue/test-utils": "2.4.8",
         "happy-dom": "^20.9.0",
         "sass-embedded": "^1.99.0",
         "vue-tsc": "^3.2.6",

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "@avshare3/api": "*",
-    "@nuxt/test-utils": "^4.0.3",
-    "@vue/test-utils": "^2.4.9",
+    "@nuxt/test-utils": "4.0.2",
+    "@vue/test-utils": "2.4.8",
     "happy-dom": "^20.9.0",
     "sass-embedded": "^1.99.0",
     "vue-tsc": "^3.2.6",
@@ -24,6 +24,6 @@
     "@pinia/nuxt": "^0.11.3",
     "nuxt": "^4.4.2",
     "pinia": "^3.0.4",
-    "vue": "^3.5.30"
+    "vue": "3.5.32"
   }
 }


### PR DESCRIPTION
vue@3.5.33 にすると vuetify の `theme.global.name` ref 変数に対する単純なテストが失敗するようになる。vue@3.5.33 か vuetify どちらかのバグとしか考えられないため、当面 vue のバージョンを 3.5.32 にピン止めする。